### PR TITLE
Add flag to sort dumpperms output.

### DIFF
--- a/src/django_perms_provisioner/management/commands/dumpperms.py
+++ b/src/django_perms_provisioner/management/commands/dumpperms.py
@@ -33,6 +33,12 @@ class Command(BaseCommand):
             default=2,
             help="Specifies the indent level to use when pretty-printing output.",
         )
+        parser.add_argument(
+            "--sort", "-S",
+            action="store_true",
+            help="Sort output keys.",
+        )
+
 
     def handle(self, **options):
         """Ouput all groups and permissions in the DB.
@@ -47,6 +53,7 @@ class Command(BaseCommand):
         """
         format = options["format"]
         indent = options["indent"]
+        sort = options["sort"]
 
         if format not in DATA_DUMPER.keys():
             available_formats = ", ".join(DATA_DUMPER.keys())
@@ -58,7 +65,8 @@ class Command(BaseCommand):
             return
 
         groups_permissions_data = []
-        for group in Group.objects.all():
+        groups = Group.objects.all() if not sort else Group.objects.order_by("name")
+        for group in groups:
             group_data = {"name": group.name}
 
             if group.permissions.exists():
@@ -72,6 +80,9 @@ class Command(BaseCommand):
                     group_data["permissions"][app_label].append(
                         f"{model_name}.{codename}"
                     )
+
+            if sort:
+                group_data = dict(sorted(group_data.items()))
 
             groups_permissions_data.append(group_data)
 

--- a/src/django_perms_provisioner/management/schemas.py
+++ b/src/django_perms_provisioner/management/schemas.py
@@ -15,7 +15,7 @@ PERMISSIONS_SCHEMA = {
                         "schema": {
                             "required": True,
                             "type": "string",
-                            "regex": "^[\w\_]+\.[\w\_]+$",
+                            "regex": r"^[\w\_]+\.[\w\_]+$",
                         },
                     },
                 },

--- a/tests/files/valid-sorted.json
+++ b/tests/files/valid-sorted.json
@@ -1,0 +1,19 @@
+{
+  "groups": [
+    {
+      "name": "Group Admin",
+      "permissions": {
+        "auth": ["group.add_group", "group.change_group", "group.delete_group"]
+      }
+    },
+    {
+      "name": "Only Group"
+    },
+    {
+      "name": "User Admin",
+      "permissions": {
+        "auth": ["user.add_user", "user.change_user", "user.delete_user"]
+      }
+    }
+  ]
+}

--- a/tests/files/valid-sorted.yaml
+++ b/tests/files/valid-sorted.yaml
@@ -1,0 +1,15 @@
+---
+groups:
+  - name: Group Admin
+    permissions:
+      auth:
+      - group.add_group
+      - group.change_group
+      - group.delete_group
+  - name: Only Group
+  - name: User Admin
+    permissions:
+      auth:
+      - user.add_user
+      - user.change_user
+      - user.delete_user

--- a/tests/test_dumpperms.py
+++ b/tests/test_dumpperms.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 
 import pytest
 import yaml
@@ -11,22 +11,25 @@ STR_LOADER_MAPPING = {"yaml": yaml.safe_load, "json": json.loads}
 
 @pytest.mark.django_db
 class TestDumpperms:
-    @pytest.mark.parametrize("filename", ["valid.yaml", "valid.json"])
-    def test_valid(self, filename, capsys):
-        name, ext = os.path.splitext(filename)
+    @pytest.mark.parametrize("input_file, expected_file", [
+        ("valid.yaml", "valid.yaml"),
+        ("valid.json", "valid.json"),
+    ])
+    def test_valid(self, input_file, expected_file, capsys):
+        input_file = Path(__file__).parent / "files" / input_file
+        expected_file = Path(__file__).parent / "files" / expected_file
 
         # first read the permissions to the DB
-        filename = os.path.join(os.path.dirname(__file__), "files", filename)
-        call_command("loadperms", filename)
+        call_command("loadperms", input_file)
         capsys.readouterr()  # Reset stdout.
 
-        # dump and capture the permissions to stdout
-        call_command("dumpperms", f"--format={ext[1:]}")
+        # dump and capture the permissions to stdout and read them back
+        call_command("dumpperms", f"--format={expected_file.suffix[1:]}")
         captured = capsys.readouterr()
 
-        loader = FILE_LOADER_MAPPING[ext[1:]]
-        with open(filename, "r") as stream:
-            contents = loader(stream)
+        loader = FILE_LOADER_MAPPING[expected_file.suffix[1:]]
+        with expected_file.open("r") as stream:
+            expected_contents = loader(stream)
 
-        str_loader = STR_LOADER_MAPPING[ext[1:]]
-        assert str_loader(captured.out) == contents, captured.out
+        str_loader = STR_LOADER_MAPPING[expected_file.suffix[1:]]
+        assert str_loader(captured.out) == expected_contents, captured.out

--- a/tests/test_dumpperms.py
+++ b/tests/test_dumpperms.py
@@ -11,20 +11,23 @@ STR_LOADER_MAPPING = {"yaml": yaml.safe_load, "json": json.loads}
 
 @pytest.mark.django_db
 class TestDumpperms:
-    @pytest.mark.parametrize("input_file, expected_file", [
-        ("valid.yaml", "valid.yaml"),
-        ("valid.json", "valid.json"),
+    @pytest.mark.parametrize("input_file, expected_file, extra_args", [
+        ("valid.yaml", "valid.yaml", None),
+        ("valid.json", "valid.json", None),
+        ("valid.json", "valid-sorted.json", ["-S"]),
+        ("valid.yaml", "valid-sorted.yaml", ["-S"]),
     ])
-    def test_valid(self, input_file, expected_file, capsys):
+    def test_valid(self, input_file, expected_file, extra_args, capsys):
         input_file = Path(__file__).parent / "files" / input_file
         expected_file = Path(__file__).parent / "files" / expected_file
+        extra_args = extra_args or []
 
         # first read the permissions to the DB
         call_command("loadperms", input_file)
         capsys.readouterr()  # Reset stdout.
 
-        # dump and capture the permissions to stdout and read them back
-        call_command("dumpperms", f"--format={expected_file.suffix[1:]}")
+        # dump and capture the permissions to stdout
+        call_command("dumpperms", f"--format={expected_file.suffix[1:]}", *extra_args)
         captured = capsys.readouterr()
 
         loader = FILE_LOADER_MAPPING[expected_file.suffix[1:]]


### PR DESCRIPTION
Use case: It may be desirable to save dumpperms output in a git repo, or other VCS. In that case, output needs to be as stable as possible, in order to have clean diffs for future updates of the file.

If the output is not stable, the diffs often contain movements of permission blocks within the file in addition to real changes of permissions. This obscures the review and auditing of these updates.

Sorting output by key "stabilizes" it, so that it does not depend on the whims of the database.